### PR TITLE
📦 : valibotのアンインストール

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.47.0",
     "tailwindcss": "3.3.3",
-    "typescript": "5.2.2",
-    "valibot": "^0.18.0"
+    "typescript": "5.2.2"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^7.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,9 +56,6 @@ dependencies:
   typescript:
     specifier: 5.2.2
     version: 5.2.2
-  valibot:
-    specifier: ^0.18.0
-    version: 0.18.0
 
 devDependencies:
   '@storybook/addon-essentials':
@@ -11237,10 +11234,6 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.9.0
     dev: true
-
-  /valibot@0.18.0:
-    resolution: {integrity: sha512-JpJ1ITTIAA4kuLDX5ygnjuMdeHryNI4cqx3vWQFisytTzH3/RBcTYJO336RSd/gRRRrYhIWf2RuST76p4TbdBw==}
-    dev: false
 
   /validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}


### PR DESCRIPTION
- 📦 : valibotのアンインストール

## アンインストール理由
パスワードと確認パスワードを比較するバリデーションを`equal`を使用して実装しようとしたが期待した動作にならなかった。
また、公式ドキュメントを見てもまだ記載がなく、情報に欠けるので今回は使用を見送る。