### PR TITLE
💄 : コーディネート登録ページの作成

### DIFF
--- a/src/app/api/forecast/route.ts
+++ b/src/app/api/forecast/route.ts
@@ -1,16 +1,20 @@
 import { NextResponse } from 'next/server'
-import { Forecast } from '@/types'
+import { ResponseForecast } from '@/types'
 
 export async function GET() {
   // TODO: ログイン機能実装後セッションデータから緯度経度を取得する
   const url =
     'https://api.open-meteo.com/v1/forecast?latitude=34.4&longitude=132.45&daily=temperature_2m_max,temperature_2m_min&timezone=Asia%2FTokyo'
 
-  const response = await fetch(url)
+  const response = await fetch(url, {
+    headers: {
+      'Accept-Language': 'ja-JP'
+    }
+  })
   if (!response.ok) {
     return NextResponse.error()
   }
-  const data: Forecast = await response.json()
+  const data: ResponseForecast = await response.json()
 
   return NextResponse.json(data)
 }

--- a/src/app/api/forecast/route.ts
+++ b/src/app/api/forecast/route.ts
@@ -9,7 +9,8 @@ export async function GET() {
   const response = await fetch(url, {
     headers: {
       'Accept-Language': 'ja-JP'
-    }
+    },
+    cache: 'no-cache'
   })
   if (!response.ok) {
     return NextResponse.error()

--- a/src/app/coordination/_components/CreateForm.tsx
+++ b/src/app/coordination/_components/CreateForm.tsx
@@ -1,4 +1,8 @@
-const CreateForm = () => {
+'use client'
+
+import { Forecast } from '@/types'
+
+const CreateForm = ({ forecastData }: { forecastData: Forecast[] }) => {
   return (
     <div>
       <form action=''>
@@ -19,46 +23,67 @@ const CreateForm = () => {
             <div className='grid gap-4 sm:grid-cols-2 md:gap-6 lg:grid-cols-3 xl:grid-cols-4 xl:gap-8'>
               {/* <div className='flex flex-col overflow-hidden rounded-lg border bg-white'> */}
               {/* <div className='flex flex-1 flex-col p-4 sm:p-6'> */}
-              <div className='flex flex-1 flex-col overflow-hidden rounded-lg border bg-white p-4 sm:p-6'>
-                <h2 className='mb-2 text-lg font-semibold text-gray-800'>
-                  <a
-                    href='#'
-                    className='transition duration-100 hover:text-indigo-500 active:text-indigo-600'
+              {/* カードコンテンツ:開始 */}
+              {forecastData.map(
+                ({ date, maxTemperature, minTemperature }, index) => (
+                  <div
+                    className='flex flex-1 flex-col overflow-hidden rounded-lg border bg-white p-4 sm:p-6'
+                    key={index}
                   >
-                    New trends in Tech
-                  </a>
-                </h2>
-
-                <p className='mb-8 text-gray-500'>
-                  This is a section of some simple filler text, also known as
-                  placeholder text. It shares some characteristics of a real
-                  written text.
-                </p>
-
-                <div className='mt-auto flex items-end justify-between'>
-                  <div className='flex items-center gap-2'>
-                    <div className='h-10 w-10 shrink-0 overflow-hidden rounded-full bg-gray-100'>
-                      {/* <img
-                          src='https://images.unsplash.com/photo-1611898872015-0571a9e38375?auto=format&q=75&fit=crop&w=64'
-                          loading='lazy'
-                          alt='Photo by Brock Wegner'
-                          className='h-full w-full object-cover object-center'
-                        /> */}
-                    </div>
-
                     <div>
-                      <span className='block text-indigo-500'>Mike Lane</span>
-                      <span className='block text-sm text-gray-400'>
-                        July 19, 2021
-                      </span>
+                      <div className=''>
+                        <p>{date}</p>
+                      </div>
+                      <div className=''>
+                        <p>最高気温&#65306;{maxTemperature}</p>
+                      </div>
+                      <div className=''>
+                        <p>最低気温&#65306;{minTemperature}</p>
+                      </div>
+                    </div>
+                    <div className='mt-3'>
+                      <div className='flex flex-col'>
+                        <label htmlFor='outerwear' className=''>
+                          アウター
+                        </label>
+                        <input
+                          id='outerwear'
+                          type='text'
+                          autoComplete='text'
+                          placeholder='例&#65306;レザージャケット'
+                          className='input input-bordered input-accent'
+                        />
+                      </div>
+                      {/* TODO: 機能実装の際、トップスは複数登録できるようにする */}
+                      <div className='mt-3 flex flex-col'>
+                        <label htmlFor='' className=''>
+                          トップス
+                        </label>
+                        <input
+                          id=''
+                          type='text'
+                          autoComplete='text'
+                          placeholder='例&#65306;Tシャツ'
+                          className='input input-bordered input-accent'
+                        />
+                      </div>
+                      <div className='mt-3 flex flex-col'>
+                        <label htmlFor='bottoms' className=''>
+                          ボトムス
+                        </label>
+                        <input
+                          id='bottoms'
+                          type='text'
+                          autoComplete='text'
+                          placeholder='例&#65306;デニムパンツ'
+                          className='input input-bordered input-accent'
+                        />
+                      </div>
                     </div>
                   </div>
-
-                  <span className='rounded border px-2 py-1 text-sm text-gray-500'>
-                    Article
-                  </span>
-                </div>
-              </div>
+                )
+              )}
+              {/* カードコンテンツ:終了 */}
               {/* </div> */}
             </div>
           </div>

--- a/src/app/coordination/_components/CreateForm.tsx
+++ b/src/app/coordination/_components/CreateForm.tsx
@@ -1,0 +1,71 @@
+const CreateForm = () => {
+  return (
+    <div>
+      <form action=''>
+        <div className='bg-white py-6 sm:py-8 lg:py-12'>
+          <div className='mx-auto max-w-screen-2xl px-4 md:px-8'>
+            <div className='mb-10 md:mb-16'>
+              <h2 className='mb-4 text-center text-2xl font-bold text-gray-800 md:mb-6 lg:text-3xl'>
+                Blog
+              </h2>
+
+              <p className='mx-auto max-w-screen-md text-center text-gray-500 md:text-lg'>
+                This is a section of some simple filler text, also known as
+                placeholder text. It shares some characteristics of a real
+                written text but is random or otherwise generated.
+              </p>
+            </div>
+
+            <div className='grid gap-4 sm:grid-cols-2 md:gap-6 lg:grid-cols-3 xl:grid-cols-4 xl:gap-8'>
+              {/* <div className='flex flex-col overflow-hidden rounded-lg border bg-white'> */}
+              {/* <div className='flex flex-1 flex-col p-4 sm:p-6'> */}
+              <div className='flex flex-1 flex-col overflow-hidden rounded-lg border bg-white p-4 sm:p-6'>
+                <h2 className='mb-2 text-lg font-semibold text-gray-800'>
+                  <a
+                    href='#'
+                    className='transition duration-100 hover:text-indigo-500 active:text-indigo-600'
+                  >
+                    New trends in Tech
+                  </a>
+                </h2>
+
+                <p className='mb-8 text-gray-500'>
+                  This is a section of some simple filler text, also known as
+                  placeholder text. It shares some characteristics of a real
+                  written text.
+                </p>
+
+                <div className='mt-auto flex items-end justify-between'>
+                  <div className='flex items-center gap-2'>
+                    <div className='h-10 w-10 shrink-0 overflow-hidden rounded-full bg-gray-100'>
+                      {/* <img
+                          src='https://images.unsplash.com/photo-1611898872015-0571a9e38375?auto=format&q=75&fit=crop&w=64'
+                          loading='lazy'
+                          alt='Photo by Brock Wegner'
+                          className='h-full w-full object-cover object-center'
+                        /> */}
+                    </div>
+
+                    <div>
+                      <span className='block text-indigo-500'>Mike Lane</span>
+                      <span className='block text-sm text-gray-400'>
+                        July 19, 2021
+                      </span>
+                    </div>
+                  </div>
+
+                  <span className='rounded border px-2 py-1 text-sm text-gray-500'>
+                    Article
+                  </span>
+                </div>
+              </div>
+              {/* </div> */}
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+export default CreateForm

--- a/src/app/coordination/_components/CreateForm.tsx
+++ b/src/app/coordination/_components/CreateForm.tsx
@@ -1,94 +1,121 @@
 'use client'
 
-import { Forecast } from '@/types'
+import { useForm, useFieldArray } from 'react-hook-form'
+import { Forecast, CoordinateFormItems } from '@/types'
 
 const CreateForm = ({ forecastData }: { forecastData: Forecast[] }) => {
+  const { register, control, handleSubmit } = useForm({
+    defaultValues: {
+      items: forecastData.map(() => ({ outerwear: '', tops: '', bottoms: '' }))
+    }
+  })
+  const { fields } = useFieldArray({
+    control,
+    name: 'items'
+  })
+
+  const handleOnSubmit = (data: CoordinateFormItems) => {
+    // TODO: コーディネートデータを露登録するAPIができたら実装する
+    console.log(data.items)
+  }
+
   return (
     <div>
-      <form action=''>
-        <div className='bg-white py-6 sm:py-8 lg:py-12'>
-          <div className='mx-auto max-w-screen-2xl px-4 md:px-8'>
-            <div className='mb-10 md:mb-16'>
-              <h2 className='mb-4 text-center text-2xl font-bold text-gray-800 md:mb-6 lg:text-3xl'>
-                Blog
-              </h2>
+      <div className='bg-white py-6 sm:py-8 lg:py-12'>
+        <div className='mx-auto max-w-screen-2xl px-4 md:px-8'>
+          <div className='mb-10 md:mb-16'>
+            <h2 className='mb-4 text-center text-2xl font-bold text-gray-800 md:mb-6 lg:text-3xl'>
+              Blog
+            </h2>
 
-              <p className='mx-auto max-w-screen-md text-center text-gray-500 md:text-lg'>
-                This is a section of some simple filler text, also known as
-                placeholder text. It shares some characteristics of a real
-                written text but is random or otherwise generated.
-              </p>
-            </div>
+            <p className='mx-auto max-w-screen-md text-center text-gray-500 md:text-lg'>
+              This is a section of some simple filler text, also known as
+              placeholder text. It shares some characteristics of a real written
+              text but is random or otherwise generated.
+            </p>
+          </div>
 
+          <form
+            className=''
+            onSubmit={(event) => {
+              void handleSubmit(handleOnSubmit)(event)
+            }}
+          >
             <div className='grid gap-4 sm:grid-cols-2 md:gap-6 lg:grid-cols-3 xl:grid-cols-4 xl:gap-8'>
-              {/* <div className='flex flex-col overflow-hidden rounded-lg border bg-white'> */}
-              {/* <div className='flex flex-1 flex-col p-4 sm:p-6'> */}
-              {/* カードコンテンツ:開始 */}
-              {forecastData.map(
-                ({ date, maxTemperature, minTemperature }, index) => (
-                  <div
-                    className='flex flex-1 flex-col overflow-hidden rounded-lg border bg-white p-4 sm:p-6'
-                    key={index}
-                  >
-                    <div>
-                      <div className=''>
-                        <p>{date}</p>
-                      </div>
-                      <div className=''>
-                        <p>最高気温&#65306;{maxTemperature}</p>
-                      </div>
-                      <div className=''>
-                        <p>最低気温&#65306;{minTemperature}</p>
-                      </div>
+              {fields.map(({ id, outerwear, tops, bottoms }, index) => (
+                <div
+                  className='flex flex-1 flex-col overflow-hidden rounded-lg border bg-white p-4 sm:p-6'
+                  key={id}
+                >
+                  <div>
+                    <div className=''>
+                      <p>{forecastData[index].date}</p>
                     </div>
-                    <div className='mt-3'>
-                      <div className='flex flex-col'>
-                        <label htmlFor='outerwear' className=''>
-                          アウター
-                        </label>
-                        <input
-                          id='outerwear'
-                          type='text'
-                          autoComplete='text'
-                          placeholder='例&#65306;レザージャケット'
-                          className='input input-bordered input-accent'
-                        />
-                      </div>
-                      {/* TODO: 機能実装の際、トップスは複数登録できるようにする */}
-                      <div className='mt-3 flex flex-col'>
-                        <label htmlFor='' className=''>
-                          トップス
-                        </label>
-                        <input
-                          id=''
-                          type='text'
-                          autoComplete='text'
-                          placeholder='例&#65306;Tシャツ'
-                          className='input input-bordered input-accent'
-                        />
-                      </div>
-                      <div className='mt-3 flex flex-col'>
-                        <label htmlFor='bottoms' className=''>
-                          ボトムス
-                        </label>
-                        <input
-                          id='bottoms'
-                          type='text'
-                          autoComplete='text'
-                          placeholder='例&#65306;デニムパンツ'
-                          className='input input-bordered input-accent'
-                        />
-                      </div>
+                    <div className=''>
+                      <p>
+                        最高気温&#65306;{forecastData[index].maxTemperature}
+                      </p>
+                    </div>
+                    <div className=''>
+                      <p>
+                        最低気温&#65306;{forecastData[index].minTemperature}
+                      </p>
                     </div>
                   </div>
-                )
-              )}
-              {/* カードコンテンツ:終了 */}
-              {/* </div> */}
+                  <div className='mt-3'>
+                    <div className='flex flex-col'>
+                      <label htmlFor={`outerwear${index}`} className=''>
+                        アウター
+                      </label>
+                      <input
+                        id={`outerwear${index}`}
+                        type='text'
+                        autoComplete='text'
+                        placeholder='例&#65306;レザージャケット'
+                        className='input input-bordered input-accent'
+                        {...register(`items.${index}.outerwear`)}
+                        defaultValue={outerwear}
+                      />
+                    </div>
+                    <div className='mt-3 flex flex-col'>
+                      <label htmlFor={`tops${index}`} className=''>
+                        トップス
+                      </label>
+                      <textarea
+                        id={`tops${index}`}
+                        autoComplete='text'
+                        placeholder='例&#65306;Tシャツ'
+                        className='input input-bordered input-accent'
+                        {...register(`items.${index}.tops`)}
+                        defaultValue={tops}
+                      />
+                    </div>
+                    <div className='mt-3 flex flex-col'>
+                      <label htmlFor={`bottoms${index}`} className=''>
+                        ボトムス
+                      </label>
+                      <input
+                        id={`bottoms${index}`}
+                        type='text'
+                        autoComplete='text'
+                        placeholder='例&#65306;デニムパンツ'
+                        className='input input-bordered input-accent'
+                        {...register(`items.${index}.bottoms`)}
+                        defaultValue={bottoms}
+                      />
+                    </div>
+                  </div>
+                </div>
+              ))}
             </div>
-          </div>
+            <div className='mt-6 text-center'>
+              <button className='btn btn-primary px-10' type='submit'>
+                送信
+              </button>
+            </div>
+          </form>
         </div>
-      </form>
+      </div>
     </div>
   )
 }

--- a/src/app/coordination/create/page.tsx
+++ b/src/app/coordination/create/page.tsx
@@ -1,0 +1,21 @@
+import CreateForm from '@/app/coordination/_components/CreateForm'
+import { ResponseForecast } from '@/types'
+import { forecastDataProcessing } from '@/utils'
+
+export default async function Page() {
+  const baseUrl = process.env.NEXTAUTH_URL
+  const response = await fetch(`${baseUrl}/api/forecast`, {
+    cache: 'no-cache'
+  })
+  const forecast: ResponseForecast = await response.json()
+  if (!forecast) return
+  const forecastData = forecastDataProcessing(forecast)
+  console.log(forecastData)
+  return (
+    <div>
+      <div className='relative mx-auto my-0 h-screen w-10/12'>
+        <CreateForm />
+      </div>
+    </div>
+  )
+}

--- a/src/app/coordination/create/page.tsx
+++ b/src/app/coordination/create/page.tsx
@@ -10,11 +10,10 @@ export default async function Page() {
   const forecast: ResponseForecast = await response.json()
   if (!forecast) return
   const forecastData = forecastDataProcessing(forecast)
-  console.log(forecastData)
   return (
     <div>
       <div className='relative mx-auto my-0 h-screen w-10/12'>
-        <CreateForm />
+        <CreateForm forecastData={forecastData} />
       </div>
     </div>
   )

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -17,3 +17,10 @@ type ResponseDaily = {
 export interface ResponseForecast {
   daily: ResponseDaily
 }
+
+// 天気予報
+export type Forecast = {
+  date: string
+  maxTemperature: string
+  minTemperature: string
+}

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -24,3 +24,13 @@ export type Forecast = {
   maxTemperature: string
   minTemperature: string
 }
+
+export type CoordinationList = {
+  outerwear: string
+  tops: string
+  bottoms: string
+}
+
+export type CoordinateFormItems = {
+  items: CoordinationList[]
+}

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -7,13 +7,13 @@ export type Prefecture = {
 }
 
 // 天気取得APIの日付
-type Daily = {
+type ResponseDaily = {
   time: string[]
-}
-
-// 天教
-export interface Forecast {
-  daily: Daily
   temperature_2m_max: string[]
   temperature_2m_min: string[]
+}
+
+// 天教APIのレスポンス
+export interface ResponseForecast {
+  daily: ResponseDaily
 }

--- a/src/utils/forecastDataProcessing.ts
+++ b/src/utils/forecastDataProcessing.ts
@@ -1,0 +1,31 @@
+import { ResponseForecast, Forecast } from '@/types'
+
+export const forecastDataProcessing = (data: ResponseForecast): Forecast[] => {
+  const date = timeProcessing(data.daily.time)
+  const maxTemperature = temperatureProcessing(data.daily.temperature_2m_max)
+  const minTemperature = temperatureProcessing(data.daily.temperature_2m_min)
+  const result = date.map((date, i) => ({
+    date,
+    maxTemperature: maxTemperature[i],
+    minTemperature: minTemperature[i]
+  }))
+  return result
+}
+
+const timeProcessing = (time: string[]) => {
+  const timeMap = time.map((item) => {
+    const date = new Date(item)
+    const year = date.getFullYear()
+    const month = date.getMonth() + 1
+    const day = date.getDate()
+    return `${year}年${month}月${day}日`
+  })
+  return timeMap
+}
+
+const temperatureProcessing = (temperature: string[]) => {
+  const temperatureMap = temperature.map((item) => {
+    return `${item}℃`
+  })
+  return temperatureMap
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from '@/utils/findPrefecture'
+export * from '@/utils/forecastDataProcessing'


### PR DESCRIPTION
- ✨ : コーディネート登録ページの作成
- 🏷️ : Forecastの型をAPIのレスポンス用に修正
- 🏷️ : Forecastの型定義
- 👔 : 気温取得APIのリクエスヘッダーの追加
- ✨ : forecastDataProcessingの実装
- ➕ : utils/forecastDataProcessingのエクスポート
- 👔 : api/forecast/cache設定追加
- 👔 : coordination/create/子コンポーネントにforecastDataを渡すよう実装
- 🏷️ : CoordinateFormItemsの作成
